### PR TITLE
iDRAC module updates

### DIFF
--- a/lib/puppet/provider/drac_setting/idrac7.rb
+++ b/lib/puppet/provider/drac_setting/idrac7.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:drac_setting).provide(:idrac7) do
 
   def object_value
     fqdd = racadm_fqdd(resource[:group], resource[:object_name], resource[:object_index])
-    #result = racadm('get', fqdd).strip
+    result = racadm('get', fqdd).strip
 
     # racadm has two somewhat unpredictable response formats
     if result =~ /^\[Key=/

--- a/manifests/firmware.pp
+++ b/manifests/firmware.pp
@@ -20,13 +20,15 @@ class dell::firmware(
 
   case $::osfamily {
     'Debian' : {
-      package { 'firmware-addon-dell':
-        ensure  => $ensure,
-        require => Class['dell::repos'],
-      }
-      package { 'firmware-tools':
-        ensure  => $ensure,
-        require => Class['dell::repos'],
+      if $::operatingsystemmajrelease < '8' {
+        package { 'firmware-addon-dell':
+          ensure  => $ensure,
+          require => Class['dell::repos'],
+        }
+        package { 'firmware-tools':
+          ensure  => $ensure,
+          require => Class['dell::repos'],
+        }
       }
     }
     'RedHat' : {

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -217,9 +217,20 @@ class dell::openmanage (
     ]
   }
   if $idrac {
-    package { $idrac_packages:
-      ensure  => 'present',
-      require => Class['dell::repos'],
+    if ($::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '8') {
+      package { $idrac_packages:
+        ensure  => 'present',
+        require => Class['dell::repos'],
+      }->
+      file { '/opt/dell/srvadmin/lib/srvadmin-omilcore':
+        ensure => 'link',
+        target => '/opt/dell/srvadmin/lib64/srvadmin-omilcore'
+      }
+    } else {
+      package { $idrac_packages:
+        ensure  => 'present',
+        require => Class['dell::repos'],
+      }
     }
   }
 

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -203,7 +203,7 @@ class dell::openmanage (
   ########################################
   # iDRAC (default: true)
   ########################################
-  if $::operatingsystem == 'Debian' and $::operatingsystemajrelease == '8' {
+  if ($::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '8') {
     $idrac_packages = [
       'srvadmin-idracadm',
       'srvadmin-idracadm7',

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -87,13 +87,18 @@ class dell::openmanage (
   }
 
   # OMSA 7.2 really needs IPMI to function
+  # There is no OpemIPMI service on Debian Jessie
   case $::osfamily {
     'Debian' : {
       package { 'openipmi':
         ensure => installed,
         alias  => 'OpenIPMI',
       }
-      $ipmiservice = 'openipmi'
+      if $::operatingsystemmajrelease == '8' {
+        $ipmiservice = ''
+      } else {
+        $ipmiservice = 'openipmi'
+      }
     }
     'RedHat' : {
       package { 'OpenIPMI':
@@ -172,7 +177,7 @@ class dell::openmanage (
     mode   => '0755',
   }
 
-  if $environment != 'vagrant' {
+  if $environment != 'vagrant' and $ipmiservice != '' {
     service { $ipmiservice:
       ensure => running,
       enable => true,
@@ -198,11 +203,19 @@ class dell::openmanage (
   ########################################
   # iDRAC (default: true)
   ########################################
-  $idrac_packages = [
-    'srvadmin-idrac',
-    'srvadmin-idrac7',
-    'srvadmin-idracadm7',
-  ]
+  if $::operatingsystem == 'Debian' and $::operatingsystemajrelease == '8' {
+    $idrac_packages = [
+      'srvadmin-idracadm',
+      'srvadmin-idracadm7',
+      'srvadmin-idracadm8',
+    ]
+  } else {
+    $idrac_packages = [
+      'srvadmin-idrac',
+      'srvadmin-idrac7',
+      'srvadmin-idracadm7',
+    ]
+  }
   if $idrac {
     package { $idrac_packages:
       ensure  => 'present',

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -22,7 +22,7 @@ class dell::repos() inherits dell::params {
 
       # Dell APT Repos
       apt::key { 'dell-community':
-        key        => '34D8786F',
+        key        => '1285491434D8786F',
         key_server => 'pool.sks-keyservers.net',
       }
 

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -18,7 +18,6 @@ class dell::repos() inherits dell::params {
 
   case $::osfamily {
     'Debian' : {
-      $lc_lsbdistcodename = downcase($::lsbdistcodename)
       $lc_operatingsystem = downcase($::operatingsystem)
 
       # Dell APT Repos
@@ -28,9 +27,9 @@ class dell::repos() inherits dell::params {
       }
 
       apt::source { 'dell-community':
-        location          => 'http://linux.dell.com/repo/community/${lc_operatingsystem}',
+        location          => "http://linux.dell.com/repo/community/${lc_operatingsystem}",
         release           => '',
-        repos             => '${lc_lsbdistcodename}  openmanage',
+        repos             => 'openmanage',
         include_src       => false,
       }
 

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -22,7 +22,7 @@ class dell::repos() inherits dell::params {
 
       # Dell APT Repos
       apt::key { 'dell-community':
-        key        => '1285491434D8786F',
+        key        => '42550ABD1E80D7C1BC0BAD851285491434D8786F',
         key_server => 'pool.sks-keyservers.net',
       }
 

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -18,6 +18,8 @@ class dell::repos() inherits dell::params {
 
   case $::osfamily {
     'Debian' : {
+      $lc_lsbdistcodename = downcase($::lsbdistcodename)
+      $lc_operatingsystem = downcase($::operatingsystem)
 
       # Dell APT Repos
       apt::key { 'dell-community':
@@ -26,9 +28,9 @@ class dell::repos() inherits dell::params {
       }
 
       apt::source { 'dell-community':
-        location          => 'http://linux.dell.com/repo/community/ubuntu',
+        location          => 'http://linux.dell.com/repo/community/${lc_operatingsystem}',
         release           => '',
-        repos             => 'precise openmanage',
+        repos             => '${lc_lsbdistcodename}  openmanage',
         include_src       => false,
       }
 


### PR DESCRIPTION
Re-enable result variable in iDRAC7 configuration
Don't set the codename for repos in Debian -- results in a bogus configuration
Don't install firmware tools on Jessie -- they don't exist
Fix key import for Debian
Fix check for Debian Jessie
Ensure a symlink is created for /opt/dell/srvadmin/lib64/srvadmin-omilcore at /opt/dell/srvadmin/lib/, due to app library directory
Disable attempting to start IPMI service on Jessie -- it's not a service there, just kernel modules
Use the 40-character key for Dell repo to make Apt module happy.